### PR TITLE
os flags for unix (for compiling on windows)

### DIFF
--- a/src/trait_impls.rs
+++ b/src/trait_impls.rs
@@ -1,10 +1,13 @@
 use std::io;
 use std::any::Any;
 use std::net::SocketAddr;
+#[cfg(unix)]
 use std::path::PathBuf;
 
 use rotor::mio::Evented;
-use rotor::mio::{tcp, unix};
+use rotor::mio::tcp;
+#[cfg(unix)]
+use rotor::mio::unix;
 
 use {StreamSocket, ActiveStream, SocketError};
 
@@ -19,6 +22,7 @@ impl ActiveStream for tcp::TcpStream {
     }
 }
 
+#[cfg(unix)]
 impl ActiveStream for unix::UnixStream {
     type Address = PathBuf;
     fn connect(addr: &PathBuf) -> io::Result<Self> {
@@ -32,6 +36,7 @@ impl SocketError for tcp::TcpStream {
     }
 }
 
+#[cfg(unix)]
 impl SocketError for unix::UnixStream {
     fn take_socket_error(&self) -> io::Result<()> {
         Ok(())


### PR DESCRIPTION
Compiles on windows (MSVC)

```
PS C:\Users\John\src\rotor-stream> rustc --version --verbose
rustc 1.7.0 (a5d1e7a59 2016-02-29)
binary: rustc
commit-hash: a5d1e7a59a2a3413c377b003075349f854304b5e
commit-date: 2016-02-29
host: x86_64-pc-windows-msvc
release: 1.7.0
```
