### PR TITLE
Allow Reclamation Of Socket Inside Stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,13 +52,20 @@ use std::io;
 use std::io::{Read, Write};
 use std::error::Error;
 
-use rotor::{Evented, Time};
+use rotor::{Evented, Time, Scope, Response, Void};
 use rotor::mio::{TryAccept};
 
 pub use netbuf::{Buf, MAX_BUF_SIZE};
 
 // Any is needed to use Stream as a Seed for Machine
 pub trait StreamSocket: Read + Write + Evented + SocketError + Sized + Any {}
+
+/// Trait for migrating an existing state machine from one protocol to another.
+pub trait MigrateProtocol<P: Protocol> {
+    type Output;
+
+    fn migrate(self, seed: P::Seed, scope: &mut Scope<P::Context>) -> Response<Self::Output, Void>;
+}
 
 /// Transport is thing that provides buffered I/O for stream sockets
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,8 +62,13 @@ pub trait StreamSocket: Read + Write + Evented + SocketError + Sized + Any {}
 
 /// Trait for migrating an existing state machine from one protocol to another.
 pub trait MigrateProtocol<P: Protocol> {
+    /// Output for the migrated type.
     type Output;
 
+    /// Migrate the existing state machine to operate over the protocol `P`.
+    ///
+    /// Implementations like `Persistent` will retain their current state, so they may not call
+    /// `P::create` immediately.
     fn migrate(self, seed: P::Seed, scope: &mut Scope<P::Context>) -> Response<Self::Output, Void>;
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -215,7 +215,7 @@ impl<P, O> MigrateProtocol<P> for Stream<O> where P: Protocol, O: Protocol<Socke
     type Output = Stream<P>;
 
     fn migrate(self, seed: P::Seed, scope: &mut Scope<P::Context>) -> Response<Stream<P>, Void> {
-        Stream::<P>::connected(self.socket, seed, scope)
+        Stream::connected(self.socket, seed, scope)
     }
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -225,6 +225,11 @@ impl<P: Protocol> Accepted for Stream<P>
 }
 
 impl<P: Protocol> Stream<P> {
+    /// Destroy the `Stream` to reclaim the underlying socket.
+    pub fn destroy(self) -> P::Socket {
+        self.socket
+    }
+    
     /// Get a `Transport` object for the stream
     ///
     /// This method is only useful if you want to manipulate buffers


### PR DESCRIPTION
This would allow a user to destroy a `Stream` while retaining access to the `P::Socket`.

In my case, this functionality would be useful because I have a state machine that currently has two states:
- Handshaking
- Connected

When I detect that the handshaking state has succeeded, I want to destroy the `Stream` and get my socket back. I then want to start up another `Stream` operating over a second protocol that I can feed the socket back in to.
